### PR TITLE
Bump device-pkgs repo, add deployments for new packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 - Deployment for Dozzle as a Docker container log viewer.
 - Deployments for Prometheus metrics monitoring.
+- Deployments for various scripts to make available for running on the host.
 
 ## v2023.9.0 - 2023-12-30
 

--- a/deployments/host/avahi-daemon.deploy.yml
+++ b/deployments/host/avahi-daemon.deploy.yml
@@ -1,3 +1,0 @@
-package: github.com/PlanktoScope/device-pkgs/core/host/avahi-daemon
-features:
-disabled: false

--- a/deployments/host/dhcpcd.deploy.yml
+++ b/deployments/host/dhcpcd.deploy.yml
@@ -1,3 +1,0 @@
-package: github.com/PlanktoScope/device-pkgs/core/host/dhcpcd
-features:
-disabled: false

--- a/deployments/host/dnsmasq.deploy.yml
+++ b/deployments/host/dnsmasq.deploy.yml
@@ -1,3 +1,0 @@
-package: github.com/PlanktoScope/device-pkgs/core/host/dnsmasq
-features:
-disabled: false

--- a/deployments/host/gpsd.deploy.yml
+++ b/deployments/host/gpsd.deploy.yml
@@ -1,3 +1,0 @@
-package: github.com/PlanktoScope/device-pkgs/core/host/gpsd
-features:
-disabled: false

--- a/deployments/host/networking/autohotspot.deploy.yml
+++ b/deployments/host/networking/autohotspot.deploy.yml
@@ -1,0 +1,3 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/networking/autohotspot
+features:
+disabled: false

--- a/deployments/host/networking/avahi-daemon.deploy.yml
+++ b/deployments/host/networking/avahi-daemon.deploy.yml
@@ -1,0 +1,3 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/networking/avahi-daemon
+features:
+disabled: false

--- a/deployments/host/networking/dhcpcd.deploy.yml
+++ b/deployments/host/networking/dhcpcd.deploy.yml
@@ -1,0 +1,3 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/networking/dhcpcd
+features:
+disabled: false

--- a/deployments/host/networking/dnsmasq.deploy.yml
+++ b/deployments/host/networking/dnsmasq.deploy.yml
@@ -1,0 +1,3 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/networking/dnsmasq
+features:
+disabled: false

--- a/deployments/host/networking/interface-forwarding.deploy.yml
+++ b/deployments/host/networking/interface-forwarding.deploy.yml
@@ -1,0 +1,3 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/networking/interface-forwarding
+features:
+disabled: false

--- a/deployments/host/planktoscope/gpio-init.deploy.yml
+++ b/deployments/host/planktoscope/gpio-init.deploy.yml
@@ -1,0 +1,3 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/planktoscope/gpio-init
+features:
+disabled: false

--- a/deployments/host/planktoscope/gpsd.deploy.yml
+++ b/deployments/host/planktoscope/gpsd.deploy.yml
@@ -1,0 +1,3 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/planktoscope/gpsd
+features:
+disabled: false

--- a/deployments/host/planktoscope/machine-name.deploy.yml
+++ b/deployments/host/planktoscope/machine-name.deploy.yml
@@ -1,0 +1,3 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/planktoscope/machine-name
+features:
+disabled: false

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240114034509"
-commit: 9ce52ea57c1f7fb5b5276e1a5bee0c494e36ca10
+timestamp: "20240114165207"
+commit: 39e12e537925ebd2d124ebbe69a42c5970534a81

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240115022541"
-commit: 7bf7a50470334141bcc680ecd22f97ae0f3e13e7
+timestamp: "20240115031102"
+commit: d95787b7f9befba0a7b92754370faeb14e564575

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240114214603"
-commit: d60184bdde1aca364e244be70dfc50e1eab496c5
+timestamp: "20240114232722"
+commit: a97e7e372cf7af5e1183bbba0c0fa9d3736a7fbc

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240114183156"
-commit: ab3ea84f7fe162e5d18aaa5c94aeedfb5b380b07
+timestamp: "20240114202058"
+commit: 1ac884d6a7b8a46d3f350d0540c0ca900d2fcfc4

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240114202058"
-commit: 1ac884d6a7b8a46d3f350d0540c0ca900d2fcfc4
+timestamp: "20240114214603"
+commit: d60184bdde1aca364e244be70dfc50e1eab496c5

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240114235405"
-commit: 3816b68edb5a8f8e2c8cc0b1964b7a16dabd26a6
+timestamp: "20240115003217"
+commit: 1a808c6602d2922b1dc76a739a8215dca9914e32

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240114232722"
-commit: a97e7e372cf7af5e1183bbba0c0fa9d3736a7fbc
+timestamp: "20240114235405"
+commit: 3816b68edb5a8f8e2c8cc0b1964b7a16dabd26a6

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240114165207"
-commit: 39e12e537925ebd2d124ebbe69a42c5970534a81
+timestamp: "20240114183156"
+commit: ab3ea84f7fe162e5d18aaa5c94aeedfb5b380b07

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2023.9.0
-timestamp: "20240115003217"
-commit: 1a808c6602d2922b1dc76a739a8215dca9914e32
+timestamp: "20240115022541"
+commit: 7bf7a50470334141bcc680ecd22f97ae0f3e13e7


### PR DESCRIPTION
This PR upgrades the device-pkgs repo and adds deployments for new packages added by https://github.com/PlanktoScope/device-pkgs/pull/5 , as part of https://github.com/PlanktoScope/PlanktoScope/issues/349 .