### PR TITLE
Bump device-pkgs repo for Python segmenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 - Upgraded packages so that some now require certain files to be provided by the host.
 
+### Fixed
+
+- The container created by deployment `apps/ps/backend/proc-segmenter` now runs as the `root` user, so that it correctly handles root directories created on the host by `apps/ps/backend/controller`.
+
 ## v2024.0.0-alpha.0 - 2024-02-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ more details and usage information, refer to the
 ["Work on a development pallet"](https://github.com/PlanktoScope/forklift#work-on-a-development-pallet)
 section.
 
+The most common routine maintenance task will be to upgrade the version of the
+[`github.com/PlanktoScope/device-pkgs`](https://github.com/PlanktoScope/device-pkgs) repository used
+by this pallet. You can do that using a command like the following:
+
+```
+forklift dev --cwd {path to your local copy of the pallet for development} plt add-repo github.com/PlanktoScope/device-pkgs@{version to upgrade to}
+```
+
 ## Licensing
 
 Forklift packages deployed by this pallet have their own software licenses, as specified in the

--- a/README.md
+++ b/README.md
@@ -15,20 +15,18 @@ This Github repository has three release channels, each corresponding to a Git b
 the `stable` branch (recommended so that you will automatically be notified for new stable versions)
 or a specific Git tag.
 
-You can clone this Forklift pallet to your PlanktoScope (or any computer acting as a Docker host)
-using the [`forklift`](https://github.com/PlanktoScope/forklift) tool. For example, you can run any
-one of the `forklift` CLI commands, depending on which release of this pallet you want:
+You can clone and apply this Forklift pallet to your PlanktoScope using the
+[`forklift`](https://github.com/PlanktoScope/forklift) tool. For example, you can run any
+of the following `forklift` CLI commands, depending on which release of this pallet you want:
 ```
-// to clone and track the latest release of the edge branch:
-forklift plt clone github.com/PlanktoScope/pallet-standard@edge
+// to clone the latest development (unstable) version of the edge branch:
+forklift plt switch github.com/PlanktoScope/pallet-standard@edge
+// to clone the latest beta or stable (pre-)release of the edge branch:
+forklift plt switch github.com/PlanktoScope/pallet-standard@beta
+// to clone the latest stable release of the edge branch:
+forklift plt switch github.com/PlanktoScope/pallet-standard@stable
 // to clone the v2023.9.0 release:
-forklift plt clone github.com/PlanktoScope/pallet-standard@v2023.9.0
-```
-
-Then you can apply the cloned pallet on your PlanktoScope (or the Docker host you're running) using
-the following `forklift` CLI command:
-```
-forklift plt apply
+forklift plt switch github.com/PlanktoScope/pallet-standard@v2023.9.0
 ```
 
 Warning: this will replace all Docker containers on your Docker host with the package deployments

--- a/forklift-pallet.yml
+++ b/forklift-pallet.yml
@@ -2,5 +2,5 @@ forklift-version: v0.4.0
 
 pallet:
   path: github.com/PlanktoScope/pallet-standard
-  description: Standard configuration of Pallet package deployments for the PlanktoScope software distro
+  description: Standard configuration of Forklift package deployments for the PlanktoScope software distro
   readme-file: README.md

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-alpha.0
-timestamp: "20240227002628"
-commit: b7354552258a7e7ac3132ddff5fa0eca35d310cd
+timestamp: "20240227034045"
+commit: 3809b4ed589ee267ee37e7f57d6dc1f2b4465eb4

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-alpha.0
-timestamp: "20240226233852"
-commit: 67ad6e119a9bfdecc94fbd30394d9a1d3085feb7
+timestamp: "20240227002628"
+commit: b7354552258a7e7ac3132ddff5fa0eca35d310cd

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-alpha.0
-timestamp: "20240209195417"
-commit: 7a39f531ffcf18a3b6692690204bf808aea5c718
+timestamp: "20240226221626"
+commit: 2611bfba23cf6751b93ce774017ab227d5bd4a14

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-alpha.0
-timestamp: "20240226221626"
-commit: 2611bfba23cf6751b93ce774017ab227d5bd4a14
+timestamp: "20240226233852"
+commit: 67ad6e119a9bfdecc94fbd30394d9a1d3085feb7


### PR DESCRIPTION
This PR bumps the device-pkgs repo to incorporate the changes made by https://github.com/PlanktoScope/device-pkgs/pull/8 (and, in turn, https://github.com/PlanktoScope/device-backend/pull/22).