### PR TITLE
Provide the `machine-name` binary

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        forklift-version: [0.7.0, 0.7.1]
+        forklift-version: [0.7.2-alpha.5]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Added
+
+- Deployment `host/machine-name` now exports a `machine-name` binary built for the appropriate CPU architecture target.
+
 ## v2024.0.0-alpha.2 - 2024-04-25
 
 ### Added

--- a/forklift-pallet.yml
+++ b/forklift-pallet.yml
@@ -1,4 +1,4 @@
-forklift-version: v0.7.0
+forklift-version: v0.7.2-alpha.3
 
 pallet:
   path: github.com/PlanktoScope/pallet-standard

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-alpha.2
-timestamp: "20240515161917"
-commit: df8960a6f5edf780086abf7a681a3290545a373b
+timestamp: "20240516030852"
+commit: 58a62eb5f3cb9bcf2f5dc0f436eee6b40510a678

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-alpha.2
-timestamp: "20240429165952"
-commit: 65bb42e2bed64fe599d22f4c09b3cfee6cc500f8
+timestamp: "20240515161917"
+commit: df8960a6f5edf780086abf7a681a3290545a373b


### PR DESCRIPTION
This PR makes the `host/machine-name` package deployment self-contained by having the package deployment provide the `machine-name` binary used by the various scripts/services in that package.

This PR is associated with https://github.com/PlanktoScope/device-pkgs/pull/11 and https://github.com/PlanktoScope/PlanktoScope/pull/411.