### PR TITLE
Bump some container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 - Deployment `host/machine-name` now exports a `machine-name` binary built for the appropriate CPU architecture target.
 
+### Changed
+
+- The Docker container image has been bumped to the latest version for the `apps/ps/device-portal`, to fix some broken links and remove the links to Portainer (whose inclusion in the default PlanktoScope OS images is deprecated for v2024.0.0 of PlanktoScope OS).
+- Docker container images have been bumped to the latest version for filebrowser-related package deployments.
+
 ## v2024.0.0-alpha.2 - 2024-04-25
 
 ### Added

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-alpha.2
-timestamp: "20240525175631"
-commit: 222ee0b73caf055f80cd1bd4e0bf8b741bfcaf8c
+timestamp: "20240525192955"
+commit: 323c4224e96bcd252dee03df71fec840bb15dd18

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-alpha.2
-timestamp: "20240516030852"
-commit: 58a62eb5f3cb9bcf2f5dc0f436eee6b40510a678
+timestamp: "20240525175631"
+commit: 222ee0b73caf055f80cd1bd4e0bf8b741bfcaf8c


### PR DESCRIPTION
This PR bumps the device-pkgs repo for https://github.com/PlanktoScope/device-pkgs/pull/12, as part of https://github.com/PlanktoScope/PlanktoScope/pull/416.