### PR TITLE
Add `host/prepare-custom-image` deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Added
+
+- Added a `host/prepare-custom-image` package to export a script to `/usr/libexec/prepare-custom-image` for resetting the filesystem and shutting down the machine in preparation for cloning the filesystem as an SD card image.
+
 ## v2024.0.0-beta.1 - 2024-06-24
 
 ### Changed

--- a/deployments/host/prepare-custom-image.deploy.yml
+++ b/deployments/host/prepare-custom-image.deploy.yml
@@ -1,0 +1,2 @@
+package: github.com/PlanktoScope/device-pkgs/core/host/prepare-custom-image
+disabled: false

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-beta.1
-timestamp: "20240808030516"
-commit: caa94272e89a41541b1ec232cbb91f7c05a41e40
+timestamp: "20240808050533"
+commit: 2659e5f6a321ef3f3aee0f1f19812a9c6b18a764

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
-type: version
+type: pseudoversion
 tag: v2024.0.0-beta.1
-timestamp: "20240624135807"
-commit: 2a7968642abce0be5906a00bab6e2e363cdf3697
+timestamp: "20240807230756"
+commit: 2778f4d96027e25ca6e01b79b0577040d3e8202e

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-beta.1
-timestamp: "20240807230756"
-commit: 2778f4d96027e25ca6e01b79b0577040d3e8202e
+timestamp: "20240808030516"
+commit: caa94272e89a41541b1ec232cbb91f7c05a41e40


### PR DESCRIPTION
This PR adds a deployment for the package added by https://github.com/PlanktoScope/device-pkgs/pull/15 to assist with the process of creating customized SD card images from booted systems.