### PR TITLE
Limit Grafana CPU usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Added a `host/prepare-custom-image` package to export a script to `/usr/libexec/prepare-custom-image` for resetting the filesystem and shutting down the machine in preparation for cloning the filesystem as an SD card image.
 - Added experimental feature flags for other pallets to reference when importing files from this pallet.
 
+### Changed
+
+- Deployment `apps/grafana` now tries to limit Grafana's CPU usage to one core.
+
 ## v2024.0.0-beta.1 - 2024-06-24
 
 ### Changed

--- a/deployments/apps/grafana.deploy.yml
+++ b/deployments/apps/grafana.deploy.yml
@@ -4,4 +4,5 @@ features:
   - no-login
   - prometheus-datasource
   - host-summary-dashboard
+  - cpu-limit
 disabled: false

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-beta.1
-timestamp: "20240916054717"
-commit: d643364044e2956fe149b78ae66889e506a32a63
+timestamp: "20240919040253"
+commit: 942c988400cbab4006e0c24b8c2c88dc9335fe3a

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-beta.1
-timestamp: "20240919040253"
-commit: 942c988400cbab4006e0c24b8c2c88dc9335fe3a
+timestamp: "20240919043412"
+commit: 8cb335e5b5696eca7ba36c621ec6a206f5c23219


### PR DESCRIPTION
This PR enables the feature flag added by https://github.com/PlanktoScope/device-pkgs/pull/16 to limit Grafana's CPU usage.