### PR TITLE
Try to make CI checks run on all commit/ref pushes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,19 +1,8 @@
 name: check
 
 on:
-  push:
-    branches:
-      - main
-      - edge
-      - beta
-      - stable
-      - updatecli_**
+  push: # run on every pushed commit, since these checks are fast/cheap to run
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - auto_merge_enabled
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -6,13 +6,6 @@ on:
     branches:
       - main
       - edge
-  pull_request:
-    branches:
-      - main
-      - edge
-    paths:
-      - '.github/workflows/updatecli-*.yml'
-      - '.github/updatecli.d/*.yml'
   workflow_dispatch:
   schedule:
     - cron: '0 16 * * *'  # 16:00 UTC every day


### PR DESCRIPTION
This PR follows up on #19 by continuing to troubleshoot the failure to automatically trigger required CI checks in branches/PRs opened by updatecli (e.g. as in #23).

This PR also disables PR-based triggering of the updatecli-compose GitHub Actions workflow, since it was triggering even for PRs without changes in files matching the file path filter.