### PR TITLE
Continue troubleshooting CI checks triggering in updatecli PRs

### DIFF
--- a/.github/updatecli.d/compose-containers-automerge.yml
+++ b/.github/updatecli.d/compose-containers-automerge.yml
@@ -11,6 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       user: '{{ requiredEnv "COMMITTER_USERNAME" }}'
       email: '{{ requiredEnv "COMMITTER_EMAIL" }}'
+      commitusingapi: true # this might be needed to make CI checks work
 
 actions:
   pull-request:

--- a/.github/updatecli.d/compose-containers-pr.yml
+++ b/.github/updatecli.d/compose-containers-pr.yml
@@ -11,6 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       user: '{{ requiredEnv "COMMITTER_USERNAME" }}'
       email: '{{ requiredEnv "COMMITTER_EMAIL" }}'
+      commitusingapi: true # this might be needed to make CI checks work
 
 actions:
   pull-request:


### PR DESCRIPTION
This PR follows up on #24 and #19 by continuing to troubleshoot the failure to automatically trigger required CI checks in branches/PRs opened by updatecli (e.g. as in #23).