### PR TITLE
Try to work around inability to auto-trigger CI checks on updatecli PRs

### DIFF
--- a/.github/updatecli.d/compose-containers-automerge.yml
+++ b/.github/updatecli.d/compose-containers-automerge.yml
@@ -11,7 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       user: '{{ requiredEnv "COMMITTER_USERNAME" }}'
       email: '{{ requiredEnv "COMMITTER_EMAIL" }}'
-      commitusingapi: true # this might be needed to make CI checks work
+      commitusingapi: true # this allows commits to be signed
 
 actions:
   pull-request:

--- a/.github/updatecli.d/compose-containers-pr.yml
+++ b/.github/updatecli.d/compose-containers-pr.yml
@@ -11,7 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       user: '{{ requiredEnv "COMMITTER_USERNAME" }}'
       email: '{{ requiredEnv "COMMITTER_EMAIL" }}'
-      commitusingapi: true # this might be needed to make CI checks work
+      commitusingapi: true # this allows commits to be signed
 
 actions:
   pull-request:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,19 @@
 name: check
 
 on:
-  push: # run on every pushed commit, since these checks are fast/cheap to run
+  push:
+    branches:
+      - main
+      - edge
+      - beta
+      - stable
+      - updatecli_**
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - auto_merge_enabled  # needed for PRs opened via CI workflows without PATs
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -21,9 +21,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  containers-patch-auto:
+  # Note(ethanjli): we don't use the updatecli config for auto-merging patch updates, because that
+  # would require either making a personal access token in the PlanktoScope organization or making a
+  # GitHub App and installing it in the PlanktoScope organization, and both options are not worth
+  # the administrative hassle (since I don't have access to do those things myself).
+
+  containers-pr:
     env:
-      UPDATECLI_CONFIG: .github/updatecli.d/compose-containers-automerge.yml
+      UPDATECLI_CONFIG: .github/updatecli.d/compose-containers-pr.yml
+    needs: auto-containers # try to only make the PR after patch-level bumps are applied
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
This PR follows up on #25, #24, and #19 by trying to work around the inability to automatically trigger required CI checks in branches/PRs opened by updatecli (e.g. as in #23). This is actually a security restriction (see https://github.com/orgs/community/discussions/55906 ). The solutions (making a PAT or defining+installing a new GitHub App in the PlanktoScope organization) would be a bureaucratic hassle, so this PR attempts to make it possible for me to manually trigger CI checks by enabling auto-merge.