### PR TITLE
Fix incorrect use of img_rank field in EcoTaxa export metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Fixed
+
+- Deployment `apps/ps/backend/proc-segmenter` now correctly sets the `img_rank` metadata field of the EcoTaxa export to `1`, instead of setting it to an incrementing index which makes exports un-importable by EcoTaxa for datasets with more than ~32,000 objects.
+
 ## v2024.0.0-beta.3 - 2024-11-30
 
 ### Changed

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0-beta.3
-timestamp: "20241204161907"
-commit: 9802ad01b5feeca7f3198e5253d5e365a423cbc8
+timestamp: "20241219204922"
+commit: 9e6e973d0df13a3aa6e8c46e06b07594bbd0b08e

--- a/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
+++ b/requirements/repositories/github.com/PlanktoScope/device-pkgs/forklift-version-lock.yml
@@ -1,4 +1,4 @@
-type: version
+type: pseudoversion
 tag: v2024.0.0-beta.3
-timestamp: "20241130015713"
-commit: 00f31d99e126db8fdee9fd85d0a14d4403451966
+timestamp: "20241204161907"
+commit: 9802ad01b5feeca7f3198e5253d5e365a423cbc8


### PR DESCRIPTION
This PR integrates https://github.com/PlanktoScope/device-backend/pull/70 via https://github.com/PlanktoScope/device-pkgs/pull/19 as part of https://github.com/PlanktoScope/PlanktoScope/pull/505.