### PR TITLE
Add a toggle for DHCP default route advertisement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Added
+
+- Package `/packages/core/host/networking/interface-forwarding` (and its package deployment `host/networking/interface-forwarding`) now has a feature flag named `planktoscope-dhcp-default-route` which can be disabled so that the PlanktoScope doesn't advertise itself as a default route to the internet. This is useful when the PlanktoScope has no internet access and is connected (e.g. by Ethernet) to a Windows or macOS device which is connected to a Wi-Fi network with internet access: when the PlanktoScope advertises itself as a default route to the internet, such devices will only use the PlanktoScope to try to access the internet instead of using the Wi-Fi network to access the internet; then the feature flag can be disabled to enable such devices to access the internet in such a network topology.
+- Package `core/host/networking/interface-forwarding`'s default deployment now configures dnsmasq to advertise the PlanktoScope as a route to all IP addresses in 192.168.3.\*, 192.168.4.\*, 192.168.5.\*, 192.168.6.\*, and 192.168.7.\*, so that connected devices will now try to reach the PlanktoScope at 192.168.3.1, 192.168.4.1, ..., 192.168.7.1 even if the PlanktoScope doesn't advertise itself as a default route to the internet (i.e. even if the `planktoscope-dhcp-default-route` feature flag is disabled).
+
 ### Changed
 
-- Merged the github.com/PlanktoScope/device-pkgs repo into this pallet, by moving all packages from there into here.
+- Merged the [github.com/PlanktoScope/device-pkgs](https://github.com/PlanktoScope/device-pkgs) repo into this pallet, by moving all packages from there into here.
 
 ### Removed
 
 - Deployment `apps/portainer` (whose default enablement was deprecated in v2024.0.0-alpha.2) is now disabled by default.
+- Package `core/host/networking/dnsmasq`'s configuration of the DHCP server no longer advertises the PlanktoScope as a default route to the internet, since this breaks internet access on certain (macOS/Windows) client devices connected simultaneously to a Wi-Fi network for internet access and to a PlanktoScope via Ethernet. The overall pallet is unaffected because the `host/networking/interface-forwarding` deployment now provides that functionality by enabling the new `planktoscope-dhcp-default-route` feature flag described above.
 
 ## v2024.0.0-beta.3 - 2024-11-30
 

--- a/deployments/host/networking/interface-forwarding.deploy.yml
+++ b/deployments/host/networking/interface-forwarding.deploy.yml
@@ -1,3 +1,4 @@
 package: /packages/core/host/networking/interface-forwarding
 features:
+  - planktoscope-dhcp-default-route
 disabled: false

--- a/packages/core/apps/planktoscope/docs/compose-full-site.yml
+++ b/packages/core/apps/planktoscope/docs/compose-full-site.yml
@@ -1,3 +1,3 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:2024.0.0-beta.3@sha256:4b1a5fedc6c981402a6601d6b3733b7a560b409ed3b52dfc9b44d2c481bcfcf8
+    image: ghcr.io/planktoscope/project-docs:sha-776c201

--- a/packages/core/apps/planktoscope/docs/compose.yml
+++ b/packages/core/apps/planktoscope/docs/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:2024.0.0-beta.3-minimal@sha256:900aff77f23401a944b2d800d969779665fada14df4c27c3d3aac9bd6fa95831
+    image: ghcr.io/planktoscope/project-docs:sha-776c201-minimal
     volumes:
       - server-data:/data
       - server-config:/config

--- a/packages/core/host/networking/dnsmasq/forklift-package.yml
+++ b/packages/core/host/networking/dnsmasq/forklift-package.yml
@@ -66,12 +66,14 @@ deployment:
 features:
   planktoscope-dhcp-interfaces:
     description:
-      Enable DHCP & DNS server functionality for the PlanktoScope OS's static IP address
-      assignments on its network interfaces
+      Enable DHCP server functionality for the PlanktoScope OS's static IP address assignments on
+      its network interfaces
     provides:
       file-exports:
         - description:
-            Sets DHCP & DNS server settings on the wlan0, wlan1, eth0, eth1, and usb0 interfaces
+            Set DHCP server settings to assign IP addresses on the wlan0, wlan1, eth0, eth1, and
+            usb0 interfaces and to *not* advertise the PlanktoScope as a default route to the
+            internet
           target: overlays/etc/dnsmasq.d/30-dhcp-interfaces.conf
   custom-domain:
     description: Handle DNS requests for a custom domain set by /etc/custom-domain

--- a/packages/core/host/networking/dnsmasq/overlays/etc/dnsmasq.d/30-dhcp-interfaces.conf
+++ b/packages/core/host/networking/dnsmasq/overlays/etc/dnsmasq.d/30-dhcp-interfaces.conf
@@ -4,21 +4,16 @@ localise-queries
 
 interface=wlan1
 dhcp-range=wlan1,192.168.3.64,192.168.3.254,12h
-dhcp-option=wlan1,option:dns-server,192.168.3.1
 
 interface=wlan0
 dhcp-range=wlan0,192.168.4.64,192.168.4.254,12h
-dhcp-option=wlan0,option:dns-server,192.168.4.1
 
 interface=eth0
 dhcp-range=eth0,192.168.5.64,192.168.5.254,12h
-dhcp-option=eth0,option:dns-server,192.168.5.1
 
 interface=usb0
 dhcp-range=usb0,192.168.6.64,192.168.6.254,12h
-dhcp-option=usb0,option:dns-server,192.168.6.1
 
 interface=eth1
 dhcp-range=eth1,192.168.7.64,192.168.7.254,12h
-dhcp-option=eth1,option:dns-server,192.168.7.1
 

--- a/packages/core/host/networking/dnsmasq/overlays/etc/dnsmasq.d/30-dhcp-interfaces.conf
+++ b/packages/core/host/networking/dnsmasq/overlays/etc/dnsmasq.d/30-dhcp-interfaces.conf
@@ -4,16 +4,31 @@ localise-queries
 
 interface=wlan1
 dhcp-range=wlan1,192.168.3.64,192.168.3.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=wlan1,option:router
 
 interface=wlan0
 dhcp-range=wlan0,192.168.4.64,192.168.4.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=wlan0,option:router
 
 interface=eth0
 dhcp-range=eth0,192.168.5.64,192.168.5.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=eth0,option:router
 
 interface=usb0
 dhcp-range=usb0,192.168.6.64,192.168.6.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=usb0,option:router
 
 interface=eth1
 dhcp-range=eth1,192.168.7.64,192.168.7.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=eth1,option:router
 

--- a/packages/core/host/networking/interface-forwarding/forklift-package.yml
+++ b/packages/core/host/networking/interface-forwarding/forklift-package.yml
@@ -18,3 +18,16 @@ deployment:
         target: overlays/usr/lib/systemd/system/enable-interface-forwarding.service
       - description: systemd service enablement for enable-interface-forwarding.service
         target: overlays/etc/systemd/system/network-online.target.wants/enable-interface-forwarding.service
+      - description:
+          dnsmasq configuration to advertise the PlanktoScope as a route to all IP addresses
+          assigned by the PlanktoScope to devices connected on all interfaces.
+        target: overlays/etc/dnsmasq.d/35-dhcp-subnet-routes.conf
+
+features:
+  planktoscope-dhcp-default-route:
+    description:
+      Configure dnsmasq's DHCP server to advertise itself as a default route to the internet
+    provides:
+      file-exports:
+        - description: Sets DHCP settings on the wlan0, wlan1, eth0, eth1, and usb0 interfaces
+          target: overlays/etc/dnsmasq.d/35-dhcp-default-route.conf

--- a/packages/core/host/networking/interface-forwarding/overlays/etc/dnsmasq.d/35-dhcp-default-route.conf
+++ b/packages/core/host/networking/interface-forwarding/overlays/etc/dnsmasq.d/35-dhcp-default-route.conf
@@ -1,0 +1,17 @@
+# Advertise ourselves as a default route to the internet.
+
+interface=wlan1
+dhcp-option=wlan1,option:router,0.0.0.0
+
+interface=wlan0
+dhcp-option=wlan0,option:router,0.0.0.0
+
+interface=eth0
+dhcp-option=eth0,option:router,0.0.0.0
+
+interface=usb0
+dhcp-option=usb0,option:router,0.0.0.0
+
+interface=eth1
+dhcp-option=eth1,option:router,0.0.0.0
+

--- a/packages/core/host/networking/interface-forwarding/overlays/etc/dnsmasq.d/35-dhcp-subnet-routes.conf
+++ b/packages/core/host/networking/interface-forwarding/overlays/etc/dnsmasq.d/35-dhcp-subnet-routes.conf
@@ -1,0 +1,17 @@
+# Advertise ourselves as a route for addresses on 192.168.*.*, even if we're not a default route.
+
+interface=wlan1
+dhcp-option=wlan1,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+
+interface=wlan0
+dhcp-option=wlan0,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+
+interface=eth0
+dhcp-option=eth0,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+
+interface=usb0
+dhcp-option=usb0,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+
+interface=eth1
+dhcp-option=eth1,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+


### PR DESCRIPTION
This PR replicates the changes made in https://github.com/PlanktoScope/device-pkgs/pull/20 to the edge branch of this pallet, which no longer relies on github.com/Planktoscope/device-packages (because the packages have been moved into this pallet). You should think of this as the opposite of a backport (i.e. a "forward port") of the changes made in that PR.

Thus, this PR is part of a workaround for https://github.com/PlanktoScope/PlanktoScope/issues/201. Specifically, it moves the PlanktoScope's advertisement of itself as a default route to the internet from default behavior into a new `planktoscope-dhcp-default-route` feature flag provided by the `/packages/core/host/networking/interface-forwarding` package. Regardless of whether that feature flag is enabled, the PlanktoScope can still resolve IP addresses such as 192.168.4.1 and 192.168.5.1 from any connected interface.

In addition to the changes made originally in https://github.com/PlanktoScope/device-pkgs/pull/20, this PR also removes some lines in the dnsmasq config which appear to be redundant (for explicitly configuring the address of the dnsmasq DNS server, instead of using dnsmasq's default value).