### PR TITLE
Fix machine name generator's handling of unrecognized `LANG` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Deployment `host/docker` now has a workaround to enable compatibility with firewalld on RPi OS 12 (bookworm).
 - Various filesystem bind mounts for the Compose apps of deployments `apps/dozzle`, `apps/filebrowser-root`, `apps/node-exporter`, `apps/ps/files-logs`, `apps/ps/files-datasets`, `infra/caddy-ingress`, and `infra/prometheus` are now configured to error out of the required files (e.g. `/var/run/docker.sock`) don't exist, instead of having Docker try to automatically create those paths as directories.
 - New deployment `apps/lazydocker` provides a TUI for troubleshooting Docker systems from the terminal (particularly convenient when Dozzle can't start for some reason). For now, this deployment should be considered experimental/undocumented and thus subject to breaking changes without prior deprecations.
+- Deployment `host/machine-name` now correctly falls back to `unknown` as a machine name in `/run/machine-name` if an unrecognized (i.e. non-`en_US.UTF-8`) language is set via the `LANG` environment variable.
 
 ## v2024.0.0 - 2024-12-25
 

--- a/packages/core/host/machine-name/overlays/usr/lib/systemd/system/generate-machine-name.service
+++ b/packages/core/host/machine-name/overlays/usr/lib/systemd/system/generate-machine-name.service
@@ -9,6 +9,7 @@ Before=systemd-hostnamed.service
 
 [Service]
 Type=oneshot
+ExecStartPre=sh -c "echo 'unknown' >/run/machine-name"
 ExecStart=/usr/libexec/generate-machine-name
 
 [Install]

--- a/packages/core/host/machine-name/overlays/usr/libexec/generate-machine-name
+++ b/packages/core/host/machine-name/overlays/usr/libexec/generate-machine-name
@@ -15,9 +15,7 @@ elif [ -f /sys/firmware/devicetree/base/serial-number ] && [ -x /usr/bin/machine
   machine_name="$(
     /usr/bin/machine-name name --format=hex --sn="$serial_number" ||
       # fall back to English in case the language setting is unrecognized:
-      LANG=en_US.UTF-8 /usr/bin/machine-name name --format=hex --sn="$serial_number" ||
-      # fall through to default machine name
-      echo ""
+      LANG=en_US.UTF-8 /usr/bin/machine-name name --format=hex --sn="$serial_number"
   )"
 fi
 
@@ -29,15 +27,16 @@ if [ "$machine_name" = "" ] &&
   machine_name="$(
     /usr/bin/machine-name name --format=hex --sn="$serial_number" ||
       # fall back to English in case the language setting is unrecognized:
-      LANG=en_US.UTF-8 /usr/bin/machine-name name --format=hex --sn="$serial_number" ||
-      # fall through to default machine name
-      echo ""
+      LANG=en_US.UTF-8 /usr/bin/machine-name name --format=hex --sn="$serial_number"
   )"
 fi
 
 if [ "$machine_name" = "" ]; then
-  echo "Warning: a machine name could not be generated! Falling back to 'unknown'."
-  machine_name="unknown"
+  echo "Warning: a machine name could not be generated!"
+  if [ -f /run/machine-name ]; then
+    echo "Using default machine name: $(cat /run/machine-name)"
+  fi
+  exit 1
 fi
 
 echo "Machine name: $machine_name"

--- a/packages/core/host/machine-name/overlays/usr/libexec/generate-machine-name
+++ b/packages/core/host/machine-name/overlays/usr/libexec/generate-machine-name
@@ -11,22 +11,34 @@ if [ ! -z "$machine_name" ]; then
   echo "A machine name was manually specified in /etc/machine-name: $machine_name"
 elif [ -f /sys/firmware/devicetree/base/serial-number ] && [ -x /usr/bin/machine-name ]; then
   # Automatically generate a machine-name from the RPi serial number if needed:
-  serial_number="$(tr -d '\0' < /sys/firmware/devicetree/base/serial-number | cut -c 9-)"
-  machine_name="$(/usr/bin/machine-name name --format=hex --sn="$serial_number")"
+  serial_number="$(tr -d '\0' </sys/firmware/devicetree/base/serial-number | cut -c 9-)"
+  machine_name="$(
+    /usr/bin/machine-name name --format=hex --sn="$serial_number" ||
+      # fall back to English in case the language setting is unrecognized:
+      LANG=en_US.UTF-8 /usr/bin/machine-name name --format=hex --sn="$serial_number" ||
+      # fall through to default machine name
+      echo ""
+  )"
 fi
 
-if [ -z "$machine_name" ] && \
-    [ -f /etc/machine-id ] && \
-    [ -x /usr/bin/sha256sum ] && \
-    [ -x /usr/bin/machine-name ]; then
+if [ "$machine_name" = "" ] &&
+  [ -f /etc/machine-id ] &&
+  [ -x /usr/bin/sha256sum ] &&
+  [ -x /usr/bin/machine-name ]; then
   serial_number="$(sha256sum /etc/machine-id | cut -c 1-8)"
-  machine_name="$(/usr/bin/machine-name name --format=hex --sn="$serial_number")"
+  machine_name="$(
+    /usr/bin/machine-name name --format=hex --sn="$serial_number" ||
+      # fall back to English in case the language setting is unrecognized:
+      LANG=en_US.UTF-8 /usr/bin/machine-name name --format=hex --sn="$serial_number" ||
+      # fall through to default machine name
+      echo ""
+  )"
 fi
 
-if [ -z "$machine_name" ]; then
+if [ "$machine_name" = "" ]; then
   echo "Warning: a machine name could not be generated! Falling back to 'unknown'."
   machine_name="unknown"
 fi
 
 echo "Machine name: $machine_name"
-printf "%s" "$machine_name" > /run/machine-name
+printf "%s" "$machine_name" >/run/machine-name


### PR DESCRIPTION
This PR fixes a bug discovered/reported in the [2025-02-06 software meeting](https://docs.google.com/document/d/1AN1jaIdfKChKjMnzSd3ecjRTZGOnoglBfV9LCpevMgk/edit?tab=t.0#heading=h.zhpopnx24oy0) in which changing the system language setting (i.e. the `LANG` environment variable) away from `en_US.UTF-8`, e.g. during the graphical desktop's first-boot configuration wizard, caused the `generate-machine-name` systemd service to fail to start (and thus causes the `forklift-apply` and dnsmasq-related systemd services to fail to start), because the `generate-machine-name` service was unable to handle any LANG env var values besides `en_US.UTF-8`. This PR attempts to fix that problem by falling back to `en_US.UTF-8` as the machine name generation language for unrecognized languages.