### PR TITLE
Run segmenter as non-`root` user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - (Breaking change) The Docker network provided by deployment `infra/mosquitto` for bridged access to Mosquito is now named `mosquito` instead of `infra_mosquito_default`.
 - Deployment `host/networking/avahi-daemon`'s systemd services have been renamed from `planktoscope-mdns-alias@pkscope.service` and `planktoscope-mdns-alias@planktoscope.service` to `avahi-publish-cname@pkscope.local.service` and `avahi-publish-cname@planktoscope.local.service`.
 - The [github.com/PlanktoScope/device-pkgs](https://github.com/PlanktoScope/device-pkgs) repo has been merged into this pallet, by moving all packages from there into here, in order to simplify pallet maintenance.
+- Deployments `apps/ps/backend/proc-segmenter`, `apps/ps/files-datasets`, and `apps/ps/files-logs` now run as the `pi` user (i.e. UID 1000) instead of `root`, and the directories they manage are all owned by the `pi` user instead of `root`.
 
 ### Removed
 

--- a/packages/core/apps/planktoscope/device-backend/processing/segmenter/deploy.compose.yml
+++ b/packages/core/apps/planktoscope/device-backend/processing/segmenter/deploy.compose.yml
@@ -10,6 +10,7 @@ services:
       bind-mount-setup:
         condition: service_completed_successfully
   bind-mount-setup:
+    # This is a workaround for non-rootless Docker creating bind mounts with root ownership:
     image: docker.io/library/alpine:3.21.3
     volumes:
       - /home/pi/data:/home/pi/data

--- a/packages/core/apps/planktoscope/device-backend/processing/segmenter/deploy.compose.yml
+++ b/packages/core/apps/planktoscope/device-backend/processing/segmenter/deploy.compose.yml
@@ -5,4 +5,13 @@ services:
         source: /run/machine-name
         target: /var/lib/planktoscope/machine-name # FIXME(ethanjli): update the segmenter to read from /run/machine-name
       - /home/pi/data:/home/pi/data
-      - /home/pi/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter
+      - /home/pi/device-backend-logs:/home/pi/device-backend-logs
+    depends_on:
+      bind-mount-setup:
+        condition: service_completed_successfully
+  bind-mount-setup:
+    image: docker.io/library/alpine:3.21.3
+    volumes:
+      - /home/pi/data:/home/pi/data
+      - /home/pi/device-backend-logs:/home/pi/device-backend-logs
+    command: 'sh -c "chown -R 1000:1000 /home/pi/data /home/pi/device-backend-logs"'

--- a/packages/core/apps/planktoscope/device-backend/processing/segmenter/deployment.compose.yml
+++ b/packages/core/apps/planktoscope/device-backend/processing/segmenter/deployment.compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:pr-74
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:pr-75
     extra_hosts:
       - host.docker.internal:host-gateway
 networks:

--- a/packages/core/apps/planktoscope/device-backend/processing/segmenter/deployment.compose.yml
+++ b/packages/core/apps/planktoscope/device-backend/processing/segmenter/deployment.compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:pr-75
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-eea1e8b
     extra_hosts:
       - host.docker.internal:host-gateway
 networks:

--- a/packages/core/apps/planktoscope/device-backend/processing/segmenter/deployment.compose.yml
+++ b/packages/core/apps/planktoscope/device-backend/processing/segmenter/deployment.compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-660a088@sha256:84cbb43f6dbcb5f51afc7d4456b90dc426f169474255b3eea4503aeb1846e80d
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:pr-74
     extra_hosts:
       - host.docker.internal:host-gateway
 networks:

--- a/packages/core/apps/planktoscope/device-backend/processing/segmenter/dev-data.compose.yml
+++ b/packages/core/apps/planktoscope/device-backend/processing/segmenter/dev-data.compose.yml
@@ -2,3 +2,11 @@ services:
   server:
     volumes:
       - ~/.local/share/planktoscope/data:/home/pi/data
+    depends_on:
+      data-bind-mount-setup:
+        condition: service_completed_successfully
+  data-bind-mount-setup:
+    image: docker.io/library/alpine:3.21.3
+    volumes:
+      - ~/.local/share/planktoscope/data:/home/pi/data
+    command: 'sh -c "chown -R 1000:1000 /home/pi/data"'

--- a/packages/core/apps/planktoscope/device-backend/processing/segmenter/dev-logs.compose.yml
+++ b/packages/core/apps/planktoscope/device-backend/processing/segmenter/dev-logs.compose.yml
@@ -1,4 +1,12 @@
 services:
   server:
     volumes:
-      - ~/.local/share/planktoscope/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter
+      - ~/.local/share/planktoscope/device-backend-logs:/home/pi/device-backend-logs
+    depends_on:
+      logs-bind-mount-setup:
+        condition: service_completed_successfully
+  logs-bind-mount-setup:
+    image: docker.io/library/alpine:3.21.3
+    volumes:
+      - ~/.local/share/planktoscope/device-backend-logs:/home/pi/device-backend-logs
+    command: 'sh -c "chown -R 1000:1000 /home/pi/device-backend-logs"'

--- a/packages/core/apps/planktoscope/device-backend/processing/segmenter/object-stream-mjpeg.compose.yml
+++ b/packages/core/apps/planktoscope/device-backend/processing/segmenter/object-stream-mjpeg.compose.yml
@@ -7,6 +7,10 @@ services:
       caddy.handle_path: /ps/processing/segmenter/streams/object.mjpg
       caddy.handle_path.rewrite: "* /object.mjpg"
       caddy.handle_path.reverse_proxy: "{{upstreams 8001}}"
+  bind-mount-setup:
+    networks:
+      # This is needed so Docker doesn't complain
+      - caddy-ingress
 
 networks:
   caddy-ingress:

--- a/packages/core/apps/planktoscope/filebrowser-backend-logs/deployment.compose.yml
+++ b/packages/core/apps/planktoscope/filebrowser-backend-logs/deployment.compose.yml
@@ -3,11 +3,7 @@ services:
     image: docker.io/filebrowser/filebrowser:v2.32.0@sha256:593478e3c24c5ea9f5d7478dc549965b7bc7030707291006ce8d0b6162d3454b
     volumes:
       - /home/pi/device-backend-logs:/home/pi/device-backend-logs
-      - type: bind
-        source: /home/pi/device-backend-logs
-        target: /srv # this prevents filebrowser from making an unnamed volume
-        bind:
-          create_host_path: false
+      - /home/pi/device-backend-logs:/srv # this prevents filebrowser from making an unnamed volume
       - server-data:/database
     environment:
       - FB_DATABASE=/database/filebrowser.db
@@ -22,7 +18,8 @@ services:
     image: docker.io/library/alpine:3.21.3
     volumes:
       - server-data:/database
-    command: 'sh -c "chown -R 1000:1000 /database"'
+      - /home/pi/device-backend-logs:/home/pi/device-backend-logs
+    command: 'sh -c "chown -R 1000:1000 /database /home/pi/device-backend-logs"'
 networks:
   default:
     name: none

--- a/packages/core/apps/planktoscope/filebrowser-backend-logs/deployment.compose.yml
+++ b/packages/core/apps/planktoscope/filebrowser-backend-logs/deployment.compose.yml
@@ -12,6 +12,17 @@ services:
     environment:
       - FB_DATABASE=/database/filebrowser.db
       - FB_ROOT=/home/pi/device-backend-logs
+      # We must assign a port which is available to non-root users:
+      - FB_PORT=9000
+    user: '1000:1000'
+    depends_on:
+      volume-setup:
+        condition: service_completed_successfully
+  volume-setup:
+    image: docker.io/library/alpine:3.21.3
+    volumes:
+      - server-data:/database
+    command: 'sh -c "chown -R 1000:1000 /database"'
 networks:
   default:
     name: none

--- a/packages/core/apps/planktoscope/filebrowser-backend-logs/frontend.compose.yml
+++ b/packages/core/apps/planktoscope/filebrowser-backend-logs/frontend.compose.yml
@@ -3,14 +3,17 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 8080
       - FB_BASEURL=/admin/ps/device-backend-logs/browse
       - FB_NOAUTH=true
     labels:
       caddy: :80
       caddy.redir: /admin/ps/device-backend-logs/browse /admin/ps/device-backend-logs/browse/
       caddy.handle: /admin/ps/device-backend-logs/browse/*
-      caddy.handle.reverse_proxy: "{{upstreams 80}}"
+      caddy.handle.reverse_proxy: "{{upstreams 9000}}"
+  volume-setup:
+    networks:
+      # This is needed so Docker doesn't complain
+      - caddy-ingress
 
 networks:
   caddy-ingress:

--- a/packages/core/apps/planktoscope/filebrowser-datasets/deployment.compose.yml
+++ b/packages/core/apps/planktoscope/filebrowser-datasets/deployment.compose.yml
@@ -3,11 +3,7 @@ services:
     image: docker.io/filebrowser/filebrowser:v2.32.0@sha256:593478e3c24c5ea9f5d7478dc549965b7bc7030707291006ce8d0b6162d3454b
     volumes:
       - /home/pi/data:/home/pi/data
-      - type: bind
-        source: /home/pi/data
-        target: /srv # this prevents filebrowser from making an unnamed volume
-        bind:
-          create_host_path: false
+      - /home/pi/data:/srv # this prevents filebrowser from making an unnamed volume
       - server-data:/database
     environment:
       - FB_DATABASE=/database/filebrowser.db
@@ -22,7 +18,8 @@ services:
     image: docker.io/library/alpine:3.21.3
     volumes:
       - server-data:/database
-    command: 'sh -c "chown -R 1000:1000 /database"'
+      - /home/pi/data:/home/pi/data
+    command: 'sh -c "chown -R 1000:1000 /database /home/pi/data"'
 networks:
   default:
     name: none

--- a/packages/core/apps/planktoscope/filebrowser-datasets/deployment.compose.yml
+++ b/packages/core/apps/planktoscope/filebrowser-datasets/deployment.compose.yml
@@ -12,6 +12,17 @@ services:
     environment:
       - FB_DATABASE=/database/filebrowser.db
       - FB_ROOT=/home/pi/data
+      # We must assign a port which is available to non-root users:
+      - FB_PORT=9000
+    user: '1000:1000'
+    depends_on:
+      volume-setup:
+        condition: service_completed_successfully
+  volume-setup:
+    image: docker.io/library/alpine:3.21.3
+    volumes:
+      - server-data:/database
+    command: 'sh -c "chown -R 1000:1000 /database"'
 networks:
   default:
     name: none

--- a/packages/core/apps/planktoscope/filebrowser-datasets/frontend.compose.yml
+++ b/packages/core/apps/planktoscope/filebrowser-datasets/frontend.compose.yml
@@ -3,14 +3,17 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 8080
       - FB_BASEURL=/ps/data/browse
       - FB_NOAUTH=true
     labels:
       caddy: :80
       caddy.redir: /ps/data/browse /ps/data/browse/
       caddy.handle: /ps/data/browse/*
-      caddy.handle.reverse_proxy: "{{upstreams 80}}"
+      caddy.handle.reverse_proxy: "{{upstreams 9000}}"
+  volume-setup:
+    networks:
+      # This is needed so Docker doesn't complain
+      - caddy-ingress
 
 networks:
   caddy-ingress:


### PR DESCRIPTION
This PR integrates https://github.com/PlanktoScope/device-backend/pull/74 as part of https://github.com/PlanktoScope/PlanktoScope/pull/538 in order to try to fix `/home/pi/data` subdirectory ownership/permissions for non-root access.