### PR TITLE
Disable deployment of gpio-init package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Deployment `host/networking/hostapd` (along with its associated package `core/host/networking/hostapd`) has been replaced with deployment `host/networking/networkmanager-hotspot`.
 - Deployment `host/networking/dhcpcd` (along with its associated package `core/host/networking/dhcpcd`) has been replaced with deployment `host/networking/networkmanager`, as it is redundant with functionality provided NetworkManager.
 - Package `core/host/networking/networkmanager-dnsmasq`'s `planktoscope-dhcp-interfaces` feature flag has been removed, as it is redundant with functionality provided by NetworkManager with the configurations provided by the `core/host/networking/networkmanager` package.
+- Deployment `host/planktoscope/gpio-init`, whose exported systemd service never actually started correctly, is now disabled by default.
 
 ### Fixed
 

--- a/deployments/host/planktoscope/gpio-init.deploy.yml
+++ b/deployments/host/planktoscope/gpio-init.deploy.yml
@@ -1,3 +1,3 @@
 package: /packages/core/host/planktoscope/gpio-init
 features:
-disabled: false
+disabled: true


### PR DESCRIPTION
Ever since I migrated the `init-gpio-steppers` systemd service (now in package `core/host/planktoscope/gpio-init`) from the original PlanktoScope documentation's manual OS creation guide (which maybe doesn't exist anymore, as https://planktoscope.readthedocs.io/ has been taken off the internet and was never archived by the Internet Archive's WayBack Machine!!), that service has never actually worked. This PR disables that systemd service until someone cares enough to fix it, so that the Cockpit dashboard's sidebar's alert icon for failed system services only appears when there's an actually-relevant system service failure.