### PR TITLE
Add temporary port-80 reverse-proxying for v3 Node-RED dashboard dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ by the following information, except where otherwise indicated:
 
 Copyright Ethan Li and PlanktoScope project contributors
 
-SPDX-License-Identifier: Apache-2.0 OR BlueOak-1.0.0
+SPDX-License-Identifier: `Apache-2.0 OR BlueOak-1.0.0`
 
 You can use the source code provided here either under the
 [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)

--- a/packages/core/apps/planktoscope/node-red-dashboard/frontend.compose.yml
+++ b/packages/core/apps/planktoscope/node-red-dashboard/frontend.compose.yml
@@ -10,6 +10,13 @@ services:
       caddy.handle_2: /ps/node-red-v2/api/* # FIXME: these APIs should be provided by the Python backend instead
       caddy.handle_2.reverse_proxy: host.docker.internal:1880
 
+      # Temporary public entrypoint for development of the v3 Node-RED dashboard:
+      # TODO: replace this with a proper public entrypoint when the dashboard is ready
+      # for testing. See https://github.com/PlanktoScope/PlanktoScope/pull/554
+      caddy.redir_3: /ps/node-red-v2/dashboard /ps/node-red-v2/dashboard/
+      caddy.handle_3: /ps/node-red-v2/dashboard/*
+      caddy.handle_3.reverse_proxy: host.docker.internal:1880
+
 networks:
   caddy-ingress:
     external: true


### PR DESCRIPTION
This PR, as part of https://github.com/PlanktoScope/PlanktoScope/pull/554, makes the v3 Node-RED dashboard (https://github.com/PlanktoScope/dashboard) accessible via `/ps/node-red-v2/dashboard` accessible on port 80 via reverse-proxying from the Node-RED server at port 1880, which is no longer allowed through the firewall configuration that was added by #47.

This reverse-proxying endpoint should not be considered officially supported as part of PlanktoScope OS's public-facing interfaces - for now, it is just a temporary internal change to improve the software development experience. So I won't describe this change in `CHANGELOG.md`.