### PR TITLE
Add Cockpit origins rule to allow access via machine hostname

### DIFF
--- a/deployments/host/cockpit.deploy.yml
+++ b/deployments/host/cockpit.deploy.yml
@@ -6,6 +6,7 @@ features:
   - allow-origins-planktoscope-mdns-names
   - allow-origins-templated-custom-domain-home
   - allow-origins-templated-mdns-hostname
+  - allow-origins-templated-hostname
   - firewall-allow-direct
   - firewall-allow-public
 disabled: false

--- a/packages/core/host/cockpit/forklift-package.yml
+++ b/packages/core/host/cockpit/forklift-package.yml
@@ -163,7 +163,7 @@ features:
       file-exports:
         - description: Drop-in Cockpit origins list
           target: overlays/etc/cockpit/origins-templates.d/40-mdns-hostname
-  allow-origins-hostname:
+  allow-origins-templated-hostname:
     provides:
       description:
         "Allow accessing Cockpit via the bare hostname, e.g. 'pkscope-metal-slope-23501'"

--- a/packages/core/host/cockpit/forklift-package.yml
+++ b/packages/core/host/cockpit/forklift-package.yml
@@ -163,6 +163,13 @@ features:
       file-exports:
         - description: Drop-in Cockpit origins list
           target: overlays/etc/cockpit/origins-templates.d/40-mdns-hostname
+  allow-origins-hostname:
+    provides:
+      description:
+        "Allow accessing Cockpit via the bare hostname, e.g. 'pkscope-metal-slope-23501'"
+      file-exports:
+        - description: Drop-in Cockpit origins list
+          target: overlays/etc/cockpit/origins-templates.d/50-hostname
   firewall-allow-direct:
     description:
       Firewall configuration to allow accessing Cockpit from directly-connected devices

--- a/packages/core/host/cockpit/overlays/etc/cockpit/origins-templates.d/50-hostname
+++ b/packages/core/host/cockpit/overlays/etc/cockpit/origins-templates.d/50-hostname
@@ -1,0 +1,3 @@
+http://{hostname}
+http://{hostname}:9090
+


### PR DESCRIPTION
This PR adds Cockpit origins rules to allow access via `http://{hostname}` and `http://{hostname}:9090`, based on observations from helping @beniroquai to troubleshoot Cockpit access